### PR TITLE
fix bugs in casenum_replace

### DIFF
--- a/rime/plugins/plus/merged_test.py
+++ b/rime/plugins/plus/merged_test.py
@@ -132,7 +132,7 @@ class Testset(targets.registry.Testset):
 
 
     def casenum_replace(case_pattern, case_replace):
-      return lambda i, src: src.replace(pattern, replace.format(i))
+      return lambda i, src: src.replace(case_pattern, case_replace.format(i))
     self.exports['casenum_replace'] = casenum_replace
 
     def merged_testset(name, input_pattern):


### PR DESCRIPTION
`casenum_replace` を利用する際， `pattern` と `replace` が未定義で動作しなかったため，
`case_pattern`, `case_replace` に修正しました．

エラーは以下となります．
```
$ rime test
WARNING: A+B/tests: Validator unavailable
[ COMPILE  ] A+B/yuta1024
[  REFRUN  ] A+B/yuta1024
[  MERGE   ] A+B/tests: Generating A_Merged.diff
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/rime/core/main.py", line 158, in Main
    return InternalMain(args)
  File "/Library/Python/2.7/site-packages/rime/core/main.py", line 141, in InternalMain
    graph.Run(task)
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 331, in Run
    return self._Run(task)
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/commands.py", line 123, in TestWrapper
    results = yield task
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 358, in _Run
    value = (True, self._Run(result))
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/targets/project.py", line 80, in Test
    [problem.Test(ui) for problem in self.problems])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 353, in _Run
    value = (True, [self._Run(subtask) for subtask in result.tasks])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/targets/problem.py", line 152, in Test
    [testset.Test(ui) for testset in self.testsets])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 353, in _Run
    value = (True, [self._Run(subtask) for subtask in result.tasks])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/targets/testset.py", line 354, in Test
    [self.TestSolution(solution, ui) for solution in self.problem.solutions])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 353, in _Run
    value = (True, [self._Run(subtask) for subtask in result.tasks])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/targets/testset.py", line 360, in TestSolution
    if not (yield self.Build(ui)):
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 358, in _Run
    value = (True, self._Run(result))
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/basic/targets/testset.py", line 139, in Build
    if not (yield self._PostBuildHook(ui)):
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 358, in _Run
    value = (True, self._Run(result))
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 346, in _Run
    result = task.Throw(*value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 189, in Throw
    return self.it.throw(type, value, traceback)
  File "/Library/Python/2.7/site-packages/rime/plugins/plus/merged_test.py", line 164, in _PostBuildHook
    for testcase in self.GetMergedTestCases()]))):
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 353, in _Run
    value = (True, [self._Run(subtask) for subtask in result.tasks])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 342, in _Run
    result = task.Continue(value[1])
  File "/Library/Python/2.7/site-packages/rime/core/taskgraph.py", line 183, in Continue
    return self.it.send(value)
  File "/Library/Python/2.7/site-packages/rime/plugins/plus/merged_test.py", line 183, in _GenerateMergedTest
    self.test_merger.Run(testcases, merged_testcase, ui)
  File "/Library/Python/2.7/site-packages/rime/plugins/plus/merged_test.py", line 55, in Run
    self._ConcatenateDiff(difffiles, merged_testcase.difffile)
  File "/Library/Python/2.7/site-packages/rime/plugins/plus/merged_test.py", line 66, in _ConcatenateDiff
    f.write(self.output_replace(i + 1, files.ReadFile(src)))
  File "/Library/Python/2.7/site-packages/rime/plugins/plus/merged_test.py", line 135, in <lambda>
    return lambda i, src: src.replace(pattern, replace.format(i))
NameError: global name 'pattern' is not defined
```