### PR TITLE
Add six to install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
             'rime.core', 'rime.plugins', 'rime.plugins.judge_system',
             'rime.plugins.plus', 'rime.util'],
   package_dir={'rime': 'rime'},
+  install_requires=['six'],
   test_suite='nose.collector',
   tests_require=['nose', 'mox'],
 )


### PR DESCRIPTION
`ImportError: No module named six` と言われてしまったので追加しました。

https://github.com/icpc-jag/rime/blob/b8213bc3831dd120f453154d19299e3cfc942202/rime/core/taskgraph.py#L35