### PR TITLE
fix score.txt for multiple globs

### DIFF
--- a/rime/plugins/judge_system/atcoder.py
+++ b/rime/plugins/judge_system/atcoder.py
@@ -187,7 +187,7 @@ class AtCoderPacker(plus_commands.PackerBase):
     subtasks = testset.subtask_testcases
     if len(subtasks) > 0:
       score = '\n'.join([
-        s.name + '(' + str(s.score) + ')' + ': ' + ' '.join(s.input_patterns)
+        s.name + '(' + str(s.score) + ')' + ': ' + ','.join(s.input_patterns)
         for s in subtasks])
     else:
       score = 'All(100): *'


### PR DESCRIPTION
複数のパターンからなるサブタスクのscore.txtの出力でパターンの結合をコンマ区切りに修正しました

fix #23