### PR TITLE
Fix message

### DIFF
--- a/rime/plugins/plus/subtask.py
+++ b/rime/plugins/plus/subtask.py
@@ -93,7 +93,7 @@ class Testset(targets.registry.Testset):
                         detail=detail, allow_override=True)
                     if min_score == max_score:
                         ui.errors.Error(self,
-                                        'expected score %s does not equal to'
+                                        'expected score %s does not equal to '
                                         '%s' %
                                         (solution.expected_score, min_score))
                     else:


### PR DESCRIPTION
修正前

```
ERROR: problem_name/test: expected score 0 does not equal to100
```

後

```
ERROR: problem_name/test: expected score 0 does not equal to 100
```