### PR TITLE
add python 3.6, 3.7 and drop 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
     - 2.7
     - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
     - 2.7
-    - 3.4
     - 3.5
+    - 3.6
+    - 3.7
 install:
     - pip install .
     - pip install flake8 hacking pytest mock


### PR DESCRIPTION
Python 3.4 は 2019-03-19 で EOL となっているため削除し，3.6 と 3.7 を追加しました．
https://devguide.python.org/#status-of-python-branches

3.7 から xenial を求められるようなのでそのように修正しております．
https://docs.travis-ci.com/user/languages/python/#specifying-python-versions