### PR TITLE
htmlify_fullで生成されたsummary.htmlでbootstrap.cssをHTTPSで読み込む

### DIFF
--- a/rime/plugins/htmlify_full.py
+++ b/rime/plugins/htmlify_full.py
@@ -91,7 +91,7 @@ class Project(targets.registry.Project):
             u'<meta charset="utf-8"/>'
             '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com'
             '/bootstrap/3.2.0/css/bootstrap.min.css"></head>\n<body>')
-        info = u'このセクションは htmlfy_full plugin により自動生成されています '
+        info = u'このセクションは htmlify_full plugin により自動生成されています '
         info += (u'(rev.%(rev)s, uploaded by %(username)s @ %(hostname)s)\n'
                  % {'rev': rev, 'username': username, 'hostname': hostname})
         footer = u'</body></html>'
@@ -297,7 +297,7 @@ class HtmlifyFull(rime_commands.CommandBase):
         super(HtmlifyFull, self).__init__(
             'htmlify_full',
             '',
-            'Local version of htmlfy_full. (htmlify_full plugin)',
+            'Local version of htmlify_full. (htmlify_full plugin)',
             '',
             parent)
 

--- a/rime/plugins/htmlify_full.py
+++ b/rime/plugins/htmlify_full.py
@@ -89,7 +89,7 @@ class Project(targets.registry.Project):
         header = u'<!DOCTYPE html>\n<html lang="ja"><head>'
         header += (
             u'<meta charset="utf-8"/>'
-            '<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com'
+            '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com'
             '/bootstrap/3.2.0/css/bootstrap.min.css"></head>\n<body>')
         info = u'このセクションは htmlfy_full plugin により自動生成されています '
         info += (u'(rev.%(rev)s, uploaded by %(username)s @ %(hostname)s)\n'


### PR DESCRIPTION
現在、htmlify_fullで生成されたHTMLファイルで `bootstrap.min.css` をHTTPで読み込んでいます。このHTMLファイルをHTTPSプロトコルを使って提供すると、[mixed-content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content?hl=ja)となり、最悪の場合ブラウザによってブロックされ、CSSが読み込まれなくなってしまいます。

このPRでは、`bootstrap.min.css`を読み込むhrefをHTTPSのものに変更しています。