### PR TITLE
Improve DOMJudge support

### DIFF
--- a/rime/plugins/judge_system/domjudge.py
+++ b/rime/plugins/judge_system/domjudge.py
@@ -55,8 +55,8 @@ class DOMJudgePacker(plus_commands.PackerBase):
             files.MakeDir(os.path.join(pack_files_dir, 'data', 'secret'))
 
             # Generate domjudge-problem.ini
-            yaml_file = os.path.join(pack_files_dir, 'domjudge-problem.ini')
-            with open(yaml_file, 'w') as f:
+            ini_file = os.path.join(pack_files_dir, 'domjudge-problem.ini')
+            with open(ini_file, 'w') as f:
                 f.write(f'externalid = "{testset.problem.name}"\n')
                 f.write(f'short-name = "{testset.problem.id}"\n')
                 f.write(f'name = "{testset.problem.title}"\n')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
               'rime.core', 'rime.plugins', 'rime.plugins.judge_system',
               'rime.plugins.plus', 'rime.plugins.summary', 'rime.util'],
     package_dir={'rime': 'rime'},
-    install_requires=['six', 'Jinja2'],
+    install_requires=['six', 'Jinja2', 'requests'],
     tests_require=['pytest', 'mock'],
     package_data={'rime': ['plugins/summary/*.ninja']},
 )


### PR DESCRIPTION
DOMJudge への問題データのアップロード、ソースコードの提出のサポートを追加します。

最初の2つのコミットが、既存の DOMJudgePacker の修正で、必要なデータがパックされるようになります。そのあと2つのコミットで、データのアップロード、コードの提出を行なえるようにします。なお、アップロードは DOMJudge 上にコンテストがセットアップされていることを前提とし、指定したコンテストへ問題を追加します。コンテスト自体のセットアップは行いません。

使用する際には `PROJECT` / `PROBLEM` ファイルに以下のような行を追加することで、 `rime upload`, `rime submit` がサポートされます。

PROJECT:
```
use_plugin('judge_system.domjudge')
...
domjudge_config(
    url="http://example.com/",
    contest_id=3,
    username="uername",
    password="password",
)
```

PROBLEM:
```
domjudge_config(
  problem_file='ss-out/X.pdf',
  color='#000000'
)
```

このデザインは既存の arcoder_config の使われ方にならいました。この変更により古い rime では新しい PROJECT / PROBLEM ファイルが読めなくなってしまうので、 ~後方互換性~ 前方互換性が必要な場合は、別途専用の設定ファイルを追加、もしくは `problem()` / `project()` へのパラメータ追加に変更します。

https://github.com/icpc-jag/regional-2022 で実際に動くことを確認しました。