### PR TITLE
Update publish CI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install pypa/build
       run: >-
         python -m
@@ -29,11 +29,11 @@ jobs:
         --outdir dist/
         .
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
+import os
 import setuptools
+
+
+def get_long_description() -> str:
+    readme = os.path.join(os.path.dirname(__file__), "README.md")
+    with open(readme) as f:
+        return f.read()
+
 
 setuptools.setup(
     name='rime',
     version='3.0.0.dev',
+    description="An automation tool for programming contest organizers",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
     scripts=['bin/rime', 'bin/rime_init'],
     packages=['rime', 'rime.basic', 'rime.basic.targets', 'rime.basic.util',
               'rime.core', 'rime.plugins', 'rime.plugins.judge_system',


### PR DESCRIPTION
PyPIへのpublish CIが動かなくなっていたのを修正しました。
TestPyPIへのpublishが成功することは確認しました。
https://github.com/not522/rime/actions/runs/6145850000
https://test.pypi.org/project/rime/3.0.0.dev20230911/