### PR TITLE
DOMjudge 形式のリアクティブジャッジのサポート

### DIFF
--- a/rime/basic/test.py
+++ b/rime/basic/test.py
@@ -39,7 +39,7 @@ class TestCaseResult(object):
     RE = TestVerdict('Runtime Error')
     ERR = TestVerdict('System Error')
 
-    def __init__(self, solution, testcase, verdict, time, cached):
+    def __init__(self, solution=None, testcase=None, verdict=NA, time=None, cached=False):
         self.solution = solution
         self.testcase = testcase
         self.verdict = verdict

--- a/rime/plugins/judge_system/domjudge.py
+++ b/rime/plugins/judge_system/domjudge.py
@@ -183,7 +183,6 @@ class DOMJudgeReactiveTask(taskgraph.Task):
         # Don't keep proc in cache.
         judge_proc = self.judge_proc
         solution_proc = self.solution_proc
-        # TODO call terminate() or something if any of them are still alive?
         self.judge_proc = None
         self.solution_proc = None
         return (judge_proc, solution_proc)
@@ -288,6 +287,7 @@ class DOMJudgePacker(plus_commands.PackerBase):
                 not isinstance(testset.judges[0], basic_codes.InternalDiffCode)):
             judge = testset.judges[0]
 
+            # TODO support DOMJudgeReactiveRunner
             if not isinstance(judge.variant, DOMJudgeJudgeRunner):
                 ui.errors.Error(
                     testset,

--- a/rime/plugins/plus/flexible_judge.py
+++ b/rime/plugins/plus/flexible_judge.py
@@ -132,10 +132,11 @@ class Testset(targets.registry.Testset):
                 timeout=testcase.timeout, precise=precise)
             # Normally, res is codes.RunResult.
             # Some reactive variants returns TestCaseResult
-            if isinstance(res, test.TestVerdict):
-                # TODO time
-                yield test.TestCaseResult(solution, testcase, res,
-                                  time=1.23, cached=False)
+            if isinstance(res, test.TestCaseResult):
+                res.solution = solution
+                res.testcase = testcase
+                res.cached = False
+                yield res
                 return
         else:
             res = yield solution.Run(
@@ -196,7 +197,10 @@ class Testset(targets.registry.Testset):
                 output=testcase.difffile,
                 timeout=None, precise=False)
             # Some reactive variants returns TestCaseResult
-            if isinstance(res, test.TestVerdict):
+            if isinstance(res, test.TestCaseResult):
+                if res.verdict != test.TestCaseResult.AC:
+                    ui.errors.Error(reference_solution, res.verdict)
+                    raise taskgraph.Bailout([False])
                 yield True
                 return
         else:

--- a/rime/plugins/plus/flexible_judge.py
+++ b/rime/plugins/plus/flexible_judge.py
@@ -130,6 +130,13 @@ class Testset(targets.registry.Testset):
                 input=testcase.infile,
                 output=outfile,
                 timeout=testcase.timeout, precise=precise)
+            # Normally, res is codes.RunResult.
+            # Some reactive variants returns TestCaseResult
+            if isinstance(res, test.TestVerdict):
+                # TODO time
+                yield test.TestCaseResult(solution, testcase, res,
+                                  time=1.23, cached=False)
+                return
         else:
             res = yield solution.Run(
                 args=(), cwd=solution.out_dir,
@@ -188,6 +195,10 @@ class Testset(targets.registry.Testset):
                 input=testcase.infile,
                 output=testcase.difffile,
                 timeout=None, precise=False)
+            # Some reactive variants returns TestCaseResult
+            if isinstance(res, test.TestVerdict):
+                yield True
+                return
         else:
             res = yield reference_solution.Run(
                 args=(), cwd=reference_solution.out_dir,


### PR DESCRIPTION
DOMjudge 形式のリアクティブジャッジのサポートを追加します。

実際の使用例として、 https://github.com/tossy310/domjudge-rime-example/ ここのレポジトリにサンプル問題 `boolfind` をアップロードしてあります。

---

この PR では `DOMJudgeReactiveRunner` と `DOMJudgeReactiveTask` を追加します。前者は作問時に実際に `TESTS` から指定することになるジャッジ、後者はランナーが内部的に使用し、 rime の task graph の task となり実際にプロセスを実行する責務を負うクラスです。

DOMjudge では、ジャッジプロセスと提出コード実行プロセスの2つを、それぞれの標準入出力をパイプでつなぐことによりリアクティブが実行されます。ジャッジプロセスには実行時の引数として、入力データファイル等が渡されます。

実際のDOMjudgeでは2つのプロセスの間にさらに橋渡しをするプログラムが存在していますが、今回は簡単のために直接両者をパイプでつなぎました。

また、今までのrimeではテストケースごとに (1) リアクティブの実行により何かしらのテキストがジャッジから出力され、(2) その出力を想定の出力との比較を実行すること、で最終的なテストケースの実行結果を判定していました。すなわち2ステップのプログラム実行によりテストケースの判定結果を決めていました。 DOMjudge ではジャッジプロセスの終了コードにより、テストケースの実行結果を判定するため、(1) の実行のみで判定が完了する必要があります。そのため、`DOMJudgeReactiveRunner` はテストケースの判定結果 `TestCaseResult` を直接呼び出し元に返すようにし、その対応のために `flexible_judge.py` にロジックの変更が入っています。