### PR TITLE
Fix DOMjudge reactive task race condition

### DIFF
--- a/rime/plugins/judge_system/domjudge.py
+++ b/rime/plugins/judge_system/domjudge.py
@@ -191,6 +191,9 @@ class DOMJudgeReactiveTask(taskgraph.Task):
         if self.timer is not None:
             self.timer.cancel()
             self.timer = None
+        # Here, it's ensured that judge process is finished.
+        # Let's also make sure solution process is also finished.
+        self.solution_proc.wait()
         # Don't keep proc in cache.
         judge_proc = self.judge_proc
         solution_proc = self.solution_proc


### PR DESCRIPTION
Current implementation has an issue where `DOMJudgeReactiveTask` returns unfinished process to the caller (`DOMJudgeReactiveRunner`), and it tries to extract a return code of unfinished process.

Before the task returns the result, it should wait for the solution process ends.
