### PR TITLE
Save solution's stderr to a file under rime-out 

### DIFF
--- a/rime/basic/consts.py
+++ b/rime/basic/consts.py
@@ -15,6 +15,7 @@ JUDGE_EXT = '.judge'
 CACHE_EXT = '.cache'
 LOG_EXT = '.log'
 VALIDATION_EXT = '.validation'
+STDERR_EXT = '.stderr'
 
 RIME_OUT_DIR = 'rime-out'
 

--- a/rime/basic/targets/solution.py
+++ b/rime/basic/targets/solution.py
@@ -86,11 +86,12 @@ class Solution(targets.TargetBase, problem.ProblemComponentMixin):
         yield True
 
     @taskgraph.task_method
-    def Run(self, args, cwd, input, output, timeout, precise):
+    def Run(self, args, cwd, input, output, timeout, precise,
+            stderr_file=None):
         """Run this solution."""
         yield (yield self.code.Run(
             args=args, cwd=cwd, input=input, output=output,
-            timeout=timeout, precise=precise))
+            timeout=timeout, precise=precise, stderr_file=stderr_file))
 
     @taskgraph.task_method
     def Test(self, ui):

--- a/rime/basic/targets/testset.py
+++ b/rime/basic/targets/testset.py
@@ -507,17 +507,18 @@ class Testset(targets.TargetBase, problem.ProblemComponentMixin):
         Never cache results.
         Returns TestCaseResult.
         """
-        outfile, judgefile = [
+        outfile, judgefile, stderrfile = [
             os.path.join(
                 solution.out_dir,
                 os.path.splitext(os.path.basename(testcase.infile))[0] + ext)
-            for ext in (consts.OUT_EXT, consts.JUDGE_EXT)]
+            for ext in (consts.OUT_EXT, consts.JUDGE_EXT, consts.STDERR_EXT)]
         precise = (ui.options.precise or ui.options.parallelism <= 1)
         res = yield solution.Run(
             args=(), cwd=solution.out_dir,
             input=testcase.infile,
             output=outfile,
-            timeout=testcase.timeout, precise=precise)
+            timeout=testcase.timeout, precise=precise,
+            stderr_file=stderrfile)
         if res.status == core_codes.RunResult.TLE:
             yield test.TestCaseResult(solution, testcase,
                                       test.TestCaseResult.TLE,

--- a/rime/plugins/judge_system/domjudge.py
+++ b/rime/plugins/judge_system/domjudge.py
@@ -6,7 +6,6 @@ import requests
 import shutil
 import signal
 import subprocess
-import tempfile
 import threading
 import time
 
@@ -213,17 +212,17 @@ class DOMJudgeReactiveRunner(flexible_judge.ReactiveRunner):
         if os.path.exists(feedback_dir_name):
             shutil.rmtree(feedback_dir_name)
         os.makedirs(feedback_dir_name, exist_ok=True)
-        # 2nd argument is an "expected output" file, which is not supported
-        # in rime interactive for now.
-        # As a placeholder, using a temporary file.
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            judge_args = reactive.run_args + \
-                (input, tmpfile.name, feedback_dir_name, )
-            solution_args = args
-            task = DOMJudgeReactiveTask(
-                judge_args, solution_args,
-                cwd=cwd, timeout=timeout, exclusive=precise)
-            (judge_proc, solution_proc) = yield task
+
+        # Makes sure output file exists.
+        open(output, 'w').close()
+
+        judge_args = reactive.run_args + \
+            (input, output, feedback_dir_name, )
+        solution_args = args
+        task = DOMJudgeReactiveTask(
+            judge_args, solution_args,
+            cwd=cwd, timeout=timeout, exclusive=precise)
+        (judge_proc, solution_proc) = yield task
 
         judge_code = judge_proc.returncode
         solution_code = solution_proc.returncode


### PR DESCRIPTION
`Testset` がテストを実行する際に、既存の入出力ファイル名の指定に加えて、エラー出力先を指定して `Solution` を実行することで、今まで `/dev/null` に消えていた（もしくは標準出力を汚していた）テストの実行時の標準エラー出力をファイルに記録するようにします。

なお、通常のdiffやcustom judgeを使う提出に加えて、`DOMJudgeReactiveRunner` も対応させましたが `KUPCReactiveRunner` は想定挙動が分からないため、挙動が変わらないようにしています。

Fixes #101.

(CC: @climpet )