### PR TITLE
DOMjudge 9.0 の仕様変更への対応

### DIFF
--- a/rime/plugins/judge_system/domjudge.py
+++ b/rime/plugins/judge_system/domjudge.py
@@ -407,7 +407,7 @@ class DOMJudgeUploader(plus_commands.UploaderBase):
         contest_id = problem.project.domjudge_contest_id
 
         res = requests.get(
-            base_api_url + 'contests/%d/problems' % contest_id,
+            base_api_url + 'contests/%s/problems' % str(contest_id),
             auth=auth)
         if res.status_code != 200:
             ui.errors.Error(
@@ -415,7 +415,7 @@ class DOMJudgeUploader(plus_commands.UploaderBase):
             yield False
 
         possible_problems = [
-            p for p in res.json() if p['externalid'] == problem.name]
+            p for p in res.json() if p['id'] == problem.name]
         new_problem = len(possible_problems) == 0
 
         data = {}
@@ -427,7 +427,7 @@ class DOMJudgeUploader(plus_commands.UploaderBase):
         ui.console.PrintAction(
             'UPLOAD', problem, packed_file, progress=True)
         with open(packed_file, 'rb') as f:
-            request_url = base_api_url + 'contests/%d/problems' % contest_id
+            request_url = base_api_url + 'contests/%s/problems' % str(contest_id)
             if not dryrun:
                 res = requests.post(
                     request_url,
@@ -472,7 +472,7 @@ class DOMJudgeSubmitter(plus_commands.SubmitterBase):
 
         # Get the problem id from problems list.
         res = requests.get(
-            base_api_url + 'contests/%d/problems' % contest_id,
+            base_api_url + 'contests/%s/problems' % str(contest_id),
             auth=auth)
         if res.status_code != 200:
             ui.errors.Error(
@@ -480,7 +480,7 @@ class DOMJudgeSubmitter(plus_commands.SubmitterBase):
             yield False
 
         possible_problems = [
-            p for p in res.json() if p['externalid'] == solution.problem.name]
+            p for p in res.json() if p['id'] == solution.problem.name]
         if len(possible_problems) != 1:
             ui.errors.Error(solution, 'Problem does not exist.')
             yield False
@@ -498,7 +498,7 @@ class DOMJudgeSubmitter(plus_commands.SubmitterBase):
             solution.src_dir, solution.code.src_name)
         with open(source_code_file, 'rb') as f:
             res = requests.post(
-                base_api_url + 'contests/%d/submissions' % contest_id,
+                base_api_url + 'contests/%s/submissions' % str(contest_id),
                 data={'problem': problem_id, 'language': lang_name},
                 files={'code': f},
                 auth=auth)
@@ -515,7 +515,7 @@ class DOMJudgeSubmitter(plus_commands.SubmitterBase):
         # Poll until judge completes.
         while True:
             res = requests.get(
-                base_api_url + 'contests/%d/judgements' % contest_id,
+                base_api_url + 'contests/%s/judgements' % str(contest_id),
                 params={'submission_id': submission_id},
                 auth=auth)
             if res.status_code != 200:


### PR DESCRIPTION
DOMjudge のバージョンアップに伴って仕様がいくつか変わり、rime upload および rime submit が動かなくなっていたのでそれへの対応です。

- api から contest id として指定すべき id が external id となった関係で整数と限らなくなり、特に external id を指定しなかった際に自動で採番されるものが整数ではないです。そこで、フォーマット文字列が整数ではなく文字列を要求するようにし、引数を明示的に文字列にキャストするようにしました。
- `{cid}/problems` を get して `externalid` を参照していた部分について、返り値に `externalid` が含まれなくなっていました。中身を見た感じ `id` にほしい値が入っていそうだったので参照フィールドを変更しました。

注意点

- 少なくとも rime upload および rime submit については 2026 模擬国内で正しく動いた実績がありますが、十分なテストを保証するものではないです。
- 特に 2 つめの変更について、DOMjudge の以前のバージョンとの互換性がないと思います。
